### PR TITLE
Fixed build breaking at 7.10.2

### DIFF
--- a/Graphics/GChart/ChartItems.hs
+++ b/Graphics/GChart/ChartItems.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE FlexibleContexts #-}
 module Graphics.GChart.ChartItems (
   getChartDataFromChartM,
   addDataToChart,


### PR DESCRIPTION
It caused

```
/home/kir/git/work/haskell/hs-gchart/Graphics/GChart/ChartItems.hs:62:1:
    Non type-variable argument in the constraint: MonadState Chart m
    (Use FlexibleContexts to permit this)
    When checking that ‘getDataSetIdx’ has the inferred type
      getDataSetIdx :: forall (m :: * -> *). MonadState Chart m => m Int
```

and after the patch it builds.
